### PR TITLE
ECMS-4895: Adding @import in Site CSS crash the server

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/wcm/skin/WCMSkinResourceResolver.java
+++ b/core/services/src/main/java/org/exoplatform/services/wcm/skin/WCMSkinResourceResolver.java
@@ -76,7 +76,8 @@ public class WCMSkinResourceResolver implements ResourceResolver {
     }
     try {
       Node portalNode = livePortalService.getLivePortal(WCMCoreUtils.getSystemSessionProvider(), siteName);
-      final String cssData = WCMCoreUtils.getSiteGlobalActiveStylesheet(portalNode);
+      String pureCssData = WCMCoreUtils.getSiteGlobalActiveStylesheet(portalNode);
+      final String cssData = pureCssData.replaceAll("@import(.*)[^/]*.css(.*);", "");
       if(cssData == null)
         return null;
       return new Resource(cssPath) {


### PR DESCRIPTION
Problem analysis
    - In case of example.css file in css folder for a site, in rendering pharse, server will create another example.css containing all active css file including original example.css. If another file imports example.css, it will create a loop.

Fix description
    - Remove import the css files in the css folder of the same site
