### PR TITLE
ECMS-6753:Permisson is not consistent with case of adding category tree

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/taxonomy/impl/TaxonomyServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/taxonomy/impl/TaxonomyServiceImpl.java
@@ -314,9 +314,6 @@ public class TaxonomyServiceImpl implements TaxonomyService, Startable {
           node.setPermission(owner, PermissionType.ALL);
           if (creatorUser != null)
             node.setPermission(creatorUser, PermissionType.ALL);
-          for(Map.Entry<String, String[]> entry : taxonomyTreeDefaultUserPermissions_.entrySet()) {
-            node.setPermission(entry.getKey(), entry.getValue());
-          }
         }
         if (!node.isNodeType("exo:privilegeable"))
           node.addMixin("exo:privilegeable");


### PR DESCRIPTION
Fix description: Use permission setting in UI only instead of including default permission for addition a new category
