### PR TITLE
ECMS-6984: Replace Jboss cache to infinispan cache of authoring service

### DIFF
--- a/ext/authoring/services/src/test/resources/conf/wcm/test-publication-configuration.xml
+++ b/ext/authoring/services/src/test/resources/conf/wcm/test-publication-configuration.xml
@@ -244,7 +244,7 @@
   
   <component>
     <key>org.exoplatform.services.transaction.TransactionService</key>
-    <type>org.exoplatform.services.transaction.jbosscache.JBossTransactionsService</type>
+    <type>org.exoplatform.services.transaction.infinispan.JBossTransactionsService</type>
     <init-params>
       <value-param>
         <name>timeout</name>


### PR DESCRIPTION
Cause: When rebase develop (PLF4.3.x) we're using JCR1.16.x
==> Should be change jbosscache to infinispan - JCR-2203
