### PR TITLE
ECMS-7092: Unstable TestNewFolksonomyService.testCanEditTag1

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/folksonomy/NewFolksonomyService.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/folksonomy/NewFolksonomyService.java
@@ -234,6 +234,12 @@ public interface NewFolksonomyService {
   public void init() throws Exception;
 
   /**
+   * Initializes the predefined tag permission list
+   * @throws Exception
+   */
+  public void initTagPermissionListCache() throws Exception;
+
+  /**
    * Removes tag from a given document.
    *
    * @param tagPath Path of the tag.

--- a/core/services/src/main/java/org/exoplatform/services/cms/folksonomy/impl/NewFolksonomyServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/folksonomy/impl/NewFolksonomyServiceImpl.java
@@ -150,6 +150,7 @@ public class NewFolksonomyServiceImpl implements NewFolksonomyService, Startable
    * Implement method in Startable
    */
   public void stop() {
+    tagPermissionList.clearCache();
   }
 
 
@@ -443,7 +444,7 @@ public class NewFolksonomyServiceImpl implements NewFolksonomyService, Startable
   }
 
   /**
-   * init all avaiable TagStylePlugin
+   * init all available TagStylePlugin
    *
    * @throws Exception
    */
@@ -457,6 +458,14 @@ public class NewFolksonomyServiceImpl implements NewFolksonomyService, Startable
         }
       }
     }
+    initTagPermissionListCache();
+  }
+
+  /**
+   * init the cache tagPermissionList
+   * @throws Exception
+   */
+  public void initTagPermissionListCache() throws Exception {
     List<String> _tagPermissionList = new ArrayList<String>();
     for (TagPermissionPlugin plugin : tagPermissionPlugin_) {
       try {
@@ -467,6 +476,7 @@ public class NewFolksonomyServiceImpl implements NewFolksonomyService, Startable
         }
       }
     }
+    tagPermissionList.clearCache();
     tagPermissionList.put(TAG_PERMISSION_LIST, _tagPermissionList);
   }
 
@@ -813,6 +823,10 @@ public class NewFolksonomyServiceImpl implements NewFolksonomyService, Startable
     if (_tagPermissionList!=null && !_tagPermissionList.contains(usersOrGroups)) {
       _tagPermissionList.add(usersOrGroups);
       tagPermissionList.put(TAG_PERMISSION_LIST, _tagPermissionList);
+    } else if (_tagPermissionList == null) {
+      _tagPermissionList = new ArrayList<String>();
+      _tagPermissionList.add(usersOrGroups);
+      tagPermissionList.put(TAG_PERMISSION_LIST, _tagPermissionList);
     }
   }
 
@@ -840,10 +854,13 @@ public class NewFolksonomyServiceImpl implements NewFolksonomyService, Startable
   public boolean canEditTag(int scope, List<String> memberships) {
     if (scope == PUBLIC) {
       List<String> _tagPermissionList = tagPermissionList.get(TAG_PERMISSION_LIST);
+      if (_tagPermissionList == null || _tagPermissionList.size() == 0) {
+        return false;
+      }
       for (String membership : memberships) {
-        if (_tagPermissionList!=null && _tagPermissionList.contains(membership))
+        if (_tagPermissionList.contains(membership))
           return true;
-        if (_tagPermissionList!=null && membership.contains(":")) {
+        if (membership.contains(":")) {
           if (_tagPermissionList.contains("*" + membership.substring(membership.indexOf(":"))))
             return true;
         }

--- a/core/services/src/test/java/org/exoplatform/services/ecm/dms/folksonomy/TestNewFolksonomyService.java
+++ b/core/services/src/test/java/org/exoplatform/services/ecm/dms/folksonomy/TestNewFolksonomyService.java
@@ -793,14 +793,18 @@ public class TestNewFolksonomyService extends BaseWCMTestCase {
     List<String> memberships = new ArrayList<String>();
     memberships.add("/platform/users");
     memberships.add("/platform/guests");
+    newFolksonomyService_.initTagPermissionListCache();
     assertFalse(newFolksonomyService_.canEditTag(0, memberships));
 
     memberships.clear();
+
     memberships.add("*:/platform/administrators");
+    newFolksonomyService_.initTagPermissionListCache();
     assertTrue(newFolksonomyService_.canEditTag(0, memberships));
 
     memberships.clear();
     memberships.add("manager:/platform/administrators");
+    newFolksonomyService_.initTagPermissionListCache();
     assertTrue(newFolksonomyService_.canEditTag(0, memberships));
 
     memberships.clear();
@@ -823,10 +827,20 @@ public class TestNewFolksonomyService extends BaseWCMTestCase {
 
     List<String> memberships = new ArrayList<String>();
     memberships.add("/platform/administrators");
-    newFolksonomyService_.removeTagPermission("*:/platform/administrators");
+
+    String tagPermission = "*:/platform/administrators";
+
+    newFolksonomyService_.initTagPermissionListCache();
+    // 1 item from getTagPermissionList
+    assertTrue("Wrong initial number of item in tag permission list", newFolksonomyService_.getTagPermissionList().size() == 1);
+
+    newFolksonomyService_.removeTagPermission(tagPermission);
+    assertTrue("Wrong number of item in tag permission list after removing " + tagPermission, newFolksonomyService_.getTagPermissionList() == null || newFolksonomyService_.getTagPermissionList().size() == 0);
 
     assertFalse(newFolksonomyService_.canEditTag(0, memberships));
-    newFolksonomyService_.addTagPermission("*:/platform/administrators");
+
+    newFolksonomyService_.addTagPermission(tagPermission);
+    assertTrue("Wrong tag permission list after restoring the configuration", tagPermission.equals(newFolksonomyService_.getTagPermissionList().get(0)));
   }
 
   


### PR DESCRIPTION
Fix description:
- Separate the initialization of tagPermissionList cache from that for TagStylePlugin
- Improve testCanEditTag1 and testCanEditTag2
