### PR TITLE
ECMS-7091 [Share Content] The link path is not clickable in activity …

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/wcm/frontoffice/public/ShareContent.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/wcm/frontoffice/public/ShareContent.js
@@ -52,6 +52,7 @@
 
   ShareContent.prototype.doShare = function(){
     gj(".uiShareDocuments.resizable #textAreaInput").exoMentions('val', function(value) {
+      value = value.replace(/<br\/?>/gi, '\n').replace(/&lt;/gi, '<').replace(/&gt;/gi, '>');
       gj(".uiShareDocuments.resizable #textAreaInput").val(value);
       gj("#shareActionBtn").trigger("click");
     });


### PR DESCRIPTION
…message when sharing content with link path after dot and enter icons.
