### PR TITLE
ECMS-7239 Wrong display of PDF content after modification.

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -656,6 +656,8 @@ public class Utils {
           cleanedStr.setCharAt(i, c);
         }
         continue;
+      } else if (c == '_') {
+        continue;
       }
       if(i > 0 && !(Character.isLetterOrDigit(c) || c == '-')) {
         cleanedStr.deleteCharAt(i--);

--- a/core/webui/src/main/java/org/exoplatform/wcm/webui/Utils.java
+++ b/core/webui/src/main/java/org/exoplatform/wcm/webui/Utils.java
@@ -204,31 +204,7 @@ public class Utils {
    * @return the string
    */
   public static String cleanString(String str) {
-    Transliterator accentsconverter = Transliterator.getInstance("Latin; NFD; [:Nonspacing Mark:] Remove; NFC;");
-    str = accentsconverter.transliterate(str);
-    // the character ? seems to not be changed to d by the transliterate
-    // function
-    StringBuffer cleanedStr = new StringBuffer(str.trim());
-    // delete special character
-    for (int i = 0; i < cleanedStr.length(); i++) {
-      char c = cleanedStr.charAt(i);
-      if (c == ' ') {
-        if (i > 0 && cleanedStr.charAt(i - 1) == '-') {
-          cleanedStr.deleteCharAt(i--);
-        } else {
-          c = '-';
-          cleanedStr.setCharAt(i, c);
-        }
-        continue;
-      }
-      if (i > 0 && !(Character.isLetterOrDigit(c) || c == '-')) {
-        cleanedStr.deleteCharAt(i--);
-        continue;
-      }
-      if (i > 0 && c == '-' && cleanedStr.charAt(i - 1) == '-')
-        cleanedStr.deleteCharAt(i--);
-    }
-    return cleanedStr.toString().toLowerCase();
+    return org.exoplatform.services.cms.impl.Utils.cleanString(str);
   }
 
   /**


### PR DESCRIPTION
Solution: underscore characters should be preserved to ensure a good readability.
