### PR TITLE
[ECMS-6660][PDF Viewer] Persistent PDF files in temp folder

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/viewer/PDFViewerRESTService.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/viewer/PDFViewerRESTService.java
@@ -30,7 +30,6 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.imageio.ImageIO;
 import javax.jcr.Node;
 import javax.jcr.Session;
@@ -38,7 +37,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
-
 import org.apache.commons.lang.StringUtils;
 import org.artofsolving.jodconverter.office.OfficeException;
 import org.exoplatform.services.cache.CacheService;
@@ -54,7 +52,6 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.pdfviewer.ObjectKey;
 import org.exoplatform.services.pdfviewer.PDFViewerService;
-import org.exoplatform.services.pdfviewer.PDFViewerListener;
 import org.exoplatform.services.rest.resource.ResourceContainer;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.icepdf.core.exceptions.PDFException;
@@ -79,21 +76,17 @@ public class PDFViewerRESTService implements ResourceContainer {
   private RepositoryService repositoryService_;
   private ExoCache<Serializable, Object> pdfCache;
   private JodConverterService jodConverter_;
+  private PDFViewerService pdfViewerService_;
   private static final Log LOG  = ExoLogger.getLogger(PDFViewerRESTService.class.getName());
 
   public PDFViewerRESTService(RepositoryService repositoryService,
                               CacheService caService,
-                              JodConverterService jodConverter) throws Exception {
+                              JodConverterService jodConverter,
+                              PDFViewerService pdfViewerService) throws Exception {
     repositoryService_ = repositoryService;
     jodConverter_ = jodConverter;
-    PDFViewerService pdfViewerService = WCMCoreUtils.getService(PDFViewerService.class);
-    if(pdfViewerService != null){
-      pdfCache = pdfViewerService.getCache();
-    }else{
-      pdfCache = caService.getCacheInstance(PDFViewerRESTService.class.getName());
-    }
-    PDFViewerListener pdfViewerListener = new PDFViewerListener();
-    pdfCache.addCacheListener(pdfViewerListener);
+    pdfViewerService_ = pdfViewerService;
+    pdfCache = pdfViewerService_.getCache();
   }
 
   /**

--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/viewer/PDFViewerRESTService.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/viewer/PDFViewerRESTService.java
@@ -54,6 +54,7 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.pdfviewer.ObjectKey;
 import org.exoplatform.services.pdfviewer.PDFViewerService;
+import org.exoplatform.services.pdfviewer.PDFViewerListener;
 import org.exoplatform.services.rest.resource.ResourceContainer;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.icepdf.core.exceptions.PDFException;
@@ -91,6 +92,8 @@ public class PDFViewerRESTService implements ResourceContainer {
     }else{
       pdfCache = caService.getCacheInstance(PDFViewerRESTService.class.getName());
     }
+    PDFViewerListener pdfViewerListener = new PDFViewerListener();
+    pdfCache.addCacheListener(pdfViewerListener);
   }
 
   /**
@@ -283,11 +286,6 @@ public class PDFViewerRESTService implements ResourceContainer {
      File file = null;
      try {
        file= File.createTempFile("imageCapture1_" + pageNum,".png");
-       /*
-       file.deleteOnExit();
-         PM Comment : I removed this line because each deleteOnExit creates a reference in the JVM for future removal
-         Each JVM reference takes 1KB of system memory and leads to a memleak
-       */
        ImageIO.write(rendImage, "png", file);
      } catch (IOException e) {
        if (LOG.isErrorEnabled()) {
@@ -341,11 +339,6 @@ public class PDFViewerRESTService implements ResourceContainer {
       // cut the file name if name is too long, because OS allows only file with name < 250 characters
       name = reduceFileNameSize(name);
       content = File.createTempFile(name + "_tmp", ".pdf");
-      /*
-      file.deleteOnExit();
-        PM Comment : I removed this line because each deleteOnExit creates a reference in the JVM for future removal
-        Each JVM reference takes 1KB of system memory and leads to a memleak
-      */
       // Convert to pdf if need
       String extension = DMSMimeTypeResolver.getInstance().getExtension(mimeType);
       if ("pdf".equals(extension)) {

--- a/core/connector/src/test/resources/conf/standalone/ecms-core-connector-test-configuration.xml
+++ b/core/connector/src/test/resources/conf/standalone/ecms-core-connector-test-configuration.xml
@@ -44,7 +44,11 @@
      <key>org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator</key>
      <type>org.exoplatform.services.jcr.ext.hierarchy.impl.NodeHierarchyCreatorImpl</type>
   </component>
-  
+
+  <component>
+        <type>org.exoplatform.services.pdfviewer.PDFViewerService</type>
+  </component>
+
   <component>
      <type>org.exoplatform.wcm.connector.viewer.PDFViewerRESTService</type>
   </component>

--- a/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerListener.java
+++ b/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerListener.java
@@ -1,0 +1,68 @@
+package org.exoplatform.services.pdfviewer;
+
+import java.io.File;
+import java.io.Serializable;
+import org.exoplatform.services.cache.CacheListener;
+import org.exoplatform.services.cache.CacheListenerContext;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+/**
+ * Created by exo on 1/28/16.
+ */
+public class PDFViewerListener implements CacheListener {
+
+    private static final Log LOG = ExoLogger.getLogger(PDFViewerListener.class.getName());
+
+    public PDFViewerListener() {
+    }
+
+    @Override
+    public void onExpire(CacheListenerContext context, Serializable key, Object obj) throws Exception {
+        String path = obj.toString();
+        File file = new File(path);
+        file.delete();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Delete Expired File : " + file);
+        }
+    }
+
+    @Override
+    public void onRemove(CacheListenerContext context, Serializable key, Object obj) throws Exception {
+        String path = obj.toString();
+        File file = new File(path);
+        file.delete();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Delete Removed File : " + file);
+        }
+    }
+
+    @Override
+    public void onPut(CacheListenerContext context, Serializable key, Object obj) throws Exception {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Put object in the cache : " + obj);
+        }
+    }
+
+    @Override
+    public void onGet(CacheListenerContext context, Serializable key, Object obj) throws Exception {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Get object from the cache : " + obj);
+        }
+    }
+
+    @Override
+    public void onClearCache(CacheListenerContext context) throws Exception {
+        String property = "java.io.tmpdir";
+        File temp = new File(System.getProperty(property));
+        File[] listOfFiles = temp.listFiles();
+        for(int i = 0; i < listOfFiles.length; i++){
+            if(listOfFiles[i].isFile()) {
+                listOfFiles[i].delete();
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Delete the file: " + listOfFiles[i].getAbsolutePath());
+                }
+            }
+        }
+    }
+}

--- a/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerListener.java
+++ b/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerListener.java
@@ -1,11 +1,15 @@
 package org.exoplatform.services.pdfviewer;
 
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.Serializable;
+import java.util.List;
 import org.exoplatform.services.cache.CacheListener;
 import org.exoplatform.services.cache.CacheListenerContext;
+import org.exoplatform.services.cache.ExoCache;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 
 /**
  * Created by exo on 1/28/16.
@@ -47,7 +51,12 @@ public class PDFViewerListener implements CacheListener {
     @Override
     public void onGet(CacheListenerContext context, Serializable key, Object obj) throws Exception {
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Get object from the cache : " + obj);
+            PDFViewerService pdfViewerService = WCMCoreUtils.getService(PDFViewerService.class);
+            ExoCache pdfViewerServiceCache = pdfViewerService.getCache();
+            List Objects = pdfViewerServiceCache.getCachedObjects();
+            for (Object object : Objects) {
+                LOG.debug("Get object from the PDFViewerService cache : " + object);
+            }
         }
     }
 
@@ -55,7 +64,12 @@ public class PDFViewerListener implements CacheListener {
     public void onClearCache(CacheListenerContext context) throws Exception {
         String property = "java.io.tmpdir";
         File temp = new File(System.getProperty(property));
-        File[] listOfFiles = temp.listFiles();
+        File[] listOfFiles = temp.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name.matches(".*_tmp.*\\.pdf");
+            }
+        });
         for(int i = 0; i < listOfFiles.length; i++){
             if(listOfFiles[i].isFile()) {
                 listOfFiles[i].delete();

--- a/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerService.java
+++ b/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerService.java
@@ -207,14 +207,8 @@ public class PDFViewerService implements Startable {
 
     @Override
     public void start() {
-        try {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("PDFViewerService is started");
-            }
-        } catch (Exception e) {
-            if (LOG.isErrorEnabled()) {
-                LOG.error("Exception when PDFViewerService is started", e);
-            }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("PDFViewerService is started");
         }
     }
 


### PR DESCRIPTION
Fix description : 
- Add a new CacheListener in order to delete files from the temp folder when : 
  1. The object which ensure the storage of the file's path in the pdfcache is expired (for example when exceeding the maxSize).
  2. The clearCache() method is invoked (from jconsole as an example).
  3. The PLF server is stopped.
