### PR TITLE
ECMS-7412 : make document preview max file size and max page configurable

### DIFF
--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-services-configuration.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-services-configuration.xml
@@ -26,6 +26,16 @@
 
     <component>
         <type>org.exoplatform.services.pdfviewer.PDFViewerService</type>
+        <init-params>
+          <value-param>
+            <name>maxFileSize</name>
+            <value>${exo.ecms.documents.pdfviewer.max-file-size}</value>
+          </value-param>
+          <value-param>
+            <name>maxPages</name>
+            <value>${exo.ecms.documents.pdfviewer.max-pages}</value>
+          </value-param>
+        </init-params>
     </component>
 
     <component>

--- a/core/services/src/test/java/org/exoplatform/services/pdfviewer/TestPDFViewerService.java
+++ b/core/services/src/test/java/org/exoplatform/services/pdfviewer/TestPDFViewerService.java
@@ -1,0 +1,76 @@
+package org.exoplatform.services.pdfviewer;
+
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.services.cache.CacheService;
+import org.exoplatform.services.cms.jodconverter.JodConverterService;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+
+/**
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class TestPDFViewerService {
+
+  @Mock
+  private RepositoryService repositoryService;
+
+  @Mock
+  private CacheService cacheService;
+
+  @Mock
+  private JodConverterService jodConverterService;
+
+  @Test
+  public void shouldGetDefaultValuesWhenNoInitParams() throws Exception {
+    InitParams initParams = new InitParams();
+
+    PDFViewerService pdfViewerService = new PDFViewerService(repositoryService, cacheService, jodConverterService, initParams);
+
+    assertEquals(PDFViewerService.DEFAULT_MAX_FILE_SIZE, pdfViewerService.getMaxFileSize());
+    assertEquals(PDFViewerService.DEFAULT_MAX_PAGES, pdfViewerService.getMaxPages());
+  }
+
+  @Test
+  public void shouldGetParamValuesWhenValuesAreValidNumbers() throws Exception {
+    InitParams initParams = new InitParams();
+    ValueParam maxFileSizeValueParam = new ValueParam();
+    maxFileSizeValueParam.setName(PDFViewerService.MAX_FILE_SIZE_PARAM_NAME);
+    maxFileSizeValueParam.setValue("5");
+    initParams.addParam(maxFileSizeValueParam);
+    ValueParam maxPagesValueParam = new ValueParam();
+    maxPagesValueParam.setName(PDFViewerService.MAX_PAGES_PARAM_NAME);
+    maxPagesValueParam.setValue("10");
+    initParams.addParam(maxPagesValueParam);
+
+    PDFViewerService pdfViewerService = new PDFViewerService(repositoryService, cacheService, jodConverterService, initParams);
+
+    assertEquals(5 * 1024 * 1024, pdfViewerService.getMaxFileSize());
+    assertEquals(10, pdfViewerService.getMaxPages());
+  }
+
+  @Test
+  public void shouldGetParamValuesWhenValuesAreNotValidNumbers() throws Exception {
+    InitParams initParams = new InitParams();
+    ValueParam maxFileSizeValueParam = new ValueParam();
+    maxFileSizeValueParam.setName(PDFViewerService.MAX_FILE_SIZE_PARAM_NAME);
+    maxFileSizeValueParam.setValue("abc");
+    initParams.addParam(maxFileSizeValueParam);
+    ValueParam maxPagesValueParam = new ValueParam();
+    maxPagesValueParam.setName(PDFViewerService.MAX_PAGES_PARAM_NAME);
+    maxPagesValueParam.setValue("0.5");
+    initParams.addParam(maxPagesValueParam);
+
+    PDFViewerService pdfViewerService = new PDFViewerService(repositoryService, cacheService, jodConverterService, initParams);
+
+    assertEquals(PDFViewerService.DEFAULT_MAX_FILE_SIZE, pdfViewerService.getMaxFileSize());
+    assertEquals(PDFViewerService.DEFAULT_MAX_PAGES, pdfViewerService.getMaxPages());
+  }
+}

--- a/core/services/src/test/java/org/exoplatform/services/wcm/BaseWCMTestSuite.java
+++ b/core/services/src/test/java/org/exoplatform/services/wcm/BaseWCMTestSuite.java
@@ -45,6 +45,7 @@ import org.exoplatform.services.ecm.dms.view.TestApplicationTemplateManagerServi
 import org.exoplatform.services.ecm.dms.view.TestManageViewService;
 import org.exoplatform.services.ecm.dms.voting.TestVotingService;
 import org.exoplatform.services.ecm.dms.watchdocument.TestWatchDocumentService;
+import org.exoplatform.services.pdfviewer.TestPDFViewerService;
 import org.exoplatform.services.portletcache.TestFragmentCacheService;
 import org.exoplatform.services.portletcache.TestPortletFutureCache;
 import org.exoplatform.services.seo.TestSEOService;
@@ -56,6 +57,7 @@ import org.exoplatform.services.wcm.friendly.TestFriendlyService;
 import org.exoplatform.services.wcm.javascript.TestXJavaScriptService;
 import org.exoplatform.services.wcm.portal.artifacts.TestCreatePortalArtifactsService;
 import org.exoplatform.services.wcm.skin.TestXSkinService;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -108,7 +110,8 @@ import org.junit.runners.Suite.SuiteClasses;
   TestDMSConfigurationService.class,
   TestThumbnailService.class,
   TestSEOService.class,
-  TestClipboardService.class
+  TestClipboardService.class,
+  TestPDFViewerService.class
 })
 @ConfigTestCase(BaseWCMTestCase.class)
 public class BaseWCMTestSuite extends BaseExoContainerTestSuite {

--- a/core/viewer/src/main/resources/resources/templates/PDFJSViewer.gtmpl
+++ b/core/viewer/src/main/resources/resources/templates/PDFJSViewer.gtmpl
@@ -18,6 +18,7 @@
   
   UIComponent uiParent = uicomponent.getParent();
   RepositoryService rService = uicomponent.getApplicationComponent(RepositoryService.class);
+  PDFViewerService pdfViewerService = uicomponent.getApplicationComponent(PDFViewerService.class);
   String repository = rService.getCurrentRepository().getConfiguration().getName();
 
 if (uiParent != null) {
@@ -39,7 +40,7 @@ if (uiParent != null) {
   PortalRequestContext portalRequestContext = Util.getPortalRequestContext();
   def lang = portalRequestContext.getLocale().getLanguage();
 
-if (maximumPage > 0 && maximumPage <= PDFViewerService.MAX_PAGES && fileSize <= PDFViewerService.MAX_FILE_SIZE) {
+if (maximumPage > 0 && maximumPage <= pdfViewerService.getMaxPages() && fileSize <= pdfViewerService.getMaxFileSize()) {
   def jsManager = rqcontext.getJavascriptManager();
   jsManager.require("SHARED/jquery", "gj").addScripts("gj(document).ready(function() { gj(\"*[rel='tooltip']\").tooltip();});");
 
@@ -513,12 +514,12 @@ if(uicomponent.isNotModernBrowser()) {
 
     def errorMessage = _ctx.appRes("File.view.label.not-viewable");
     def pageMsg = _ctx.appRes("File.view.label.pdf-max-page");
-    pageMsg = pageMsg.replace("{0}", (String) PDFViewerService.MAX_PAGES);
+    pageMsg = pageMsg.replace("{0}", (String) pdfViewerService.getMaxPages());
     def sizeMsg = _ctx.appRes("File.view.label.pdf-max-size");
-    sizeMsg = sizeMsg.replace("{0}", (String) PDFViewerService.MAX_FILE_SIZE/(1024*1024));
-    if (maximumPage > PDFViewerService.MAX_PAGES) {
+    sizeMsg = sizeMsg.replace("{0}", (String) pdfViewerService.getMaxFileSize()/(1024*1024));
+    if (maximumPage > pdfViewerService.getMaxPages()) {
       errorMessage = pageMsg;
-    } else if (fileSize > PDFViewerService.MAX_FILE_SIZE) {
+    } else if (fileSize > pdfViewerService.getMaxFileSize()) {
       errorMessage = sizeMsg;
     }
 

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/file/views/view1.gtmpl
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/file/views/view1.gtmpl
@@ -36,7 +36,8 @@
   rcontext.getJavascriptManager().require("SHARED/ecm-browser", "browser").
   addScripts("browser.DMSBrowser.managerResize();");
   RepositoryService rService = uicomponent.getApplicationComponent(RepositoryService.class);
-  String repository = rService.getCurrentRepository().getConfiguration().getName();  
+  PDFViewerService pdfViewerService = uicomponent.getApplicationComponent(PDFViewerService.class);
+  String repository = rService.getCurrentRepository().getConfiguration().getName();
   
   
   UIPopupWindow uiPopupWindow = uicomponent.getAncestorOfType(UIPopupWindow.class);
@@ -86,7 +87,7 @@
   if (fileComponent instanceof PDFViewer) {
     fileSize = contentNode.getProperty("jcr:data").getStream().available();
     def maximumOfPage = ((PDFViewer)fileComponent).getMaximumOfPage();
-    if (maximumOfPage <= 0 || maximumOfPage > PDFViewerService.MAX_PAGES || fileSize > PDFViewerService.MAX_FILE_SIZE) {
+    if (maximumOfPage <= 0 || maximumOfPage > pdfViewerService.getMaxPages() || fileSize > pdfViewerService.getMaxFileSize()) {
       canViewPDF = false;
     }
   }


### PR DESCRIPTION
This PR adds 2 parameters to configure document limits for preview :
* exo.ecms.documents.pdfviewer.max-file-size (default value : 10)
* exo.ecms.documents.pdfviewer.max-pages (default value : 99)