### PR TITLE
PLF-6657 : add the button for presentation mode and hide it to prevent the viewer script from failing

### DIFF
--- a/core/viewer/src/main/resources/resources/templates/PDFJSViewer.gtmpl
+++ b/core/viewer/src/main/resources/resources/templates/PDFJSViewer.gtmpl
@@ -343,6 +343,8 @@ if(uicomponent.isNotModernBrowser()) {
             <!-- findbar -->
             <div id="secondaryToolbar" class="secondaryToolbar hidden">
                 <ul id="secondaryToolbarButtonContainer" class="dropdown-menu" style="display: block; top: -10px; left: -142px;">
+                    <button id="secondaryPresentationMode" class="hidden">
+                    </button>
                     <!--<li>-->
                         <!--<a id="secondaryDownload" href="<%=downloadLink%>" tabindex="21">-->
                             <!--<i class="uiIconDownload uiIconLightGray"></i> Download-->


### PR DESCRIPTION
This PR adds the button for the presentation mode, and hides it (class hidden). It allows to prevent the pdf viewer script from failing without modifying it (upgrades will be easier).