### PR TITLE
ECMS-7493 : force pdf.js in embedded mode so it does not update browser title with document name

### DIFF
--- a/apps/resources-wcm/src/main/webapp/pdf.js/viewer.js
+++ b/apps/resources-wcm/src/main/webapp/pdf.js/viewer.js
@@ -6110,7 +6110,8 @@ var PDFViewerApplication = {
   preferencePdfBugEnabled: false,
   preferenceShowPreviousViewOnLoad: true,
   preferenceDefaultZoomValue: '',
-  isViewerEmbedded: (window.parent !== window),
+  // force embedded mode so pdf.js does not update browser title with document name
+  isViewerEmbedded: true,
   url: '',
 
   // called once when the document is loaded


### PR DESCRIPTION
Force PDFViewerApplication.isViewerEmbedded to true so pdf.js does not update browser title with document name.
Pdf.js does not allow to configure this mode through its API so I did not find a better solution than changing directly the viewer.js file...