### PR TITLE
PLF-6976 PDF preview is broken

### DIFF
--- a/core/webui/src/main/java/org/exoplatform/ecm/webui/utils/Utils.java
+++ b/core/webui/src/main/java/org/exoplatform/ecm/webui/utils/Utils.java
@@ -1153,11 +1153,10 @@ public class Utils {
     PortalContainerConfig portalContainerConfig = (PortalContainerConfig) container.getComponentInstance(PortalContainerConfig.class);
     String restContextName = portalContainerConfig.getRestContextName(portalName);
     StringBuilder sb = new StringBuilder();
-    Node currentNode = org.exoplatform.wcm.webui.Utils.getRealNode(node);
-    String repository = ((ManageableRepository) currentNode.getSession().getRepository()).getConfiguration().getName();
+    String repository = ((ManageableRepository) node.getSession().getRepository()).getConfiguration().getName();
     sb.append("/").append(restContextName).append("/pdfviewer/");
     sb.append(repository).append("/");
-    sb.append(currentNode.getSession().getWorkspace().getName()).append("/").append(currentNode.getUUID());
+    sb.append(node.getSession().getWorkspace().getName()).append("/").append(node.getUUID());
     return sb.toString();
   }
 


### PR DESCRIPTION
This PR to fix https://jira.exoplatform.org/browse/ECMS-7502 after I revert part of its in https://github.com/exodev/integration/pull/80.

The root cause of ECMS-7502 is we are trying to get original node (the latest version) when try to get uri path for preview.
=> Solution: Dont try to get latest version when build uri for preview.