### PR TITLE
PLF-7779 : add dublin core metadata of files in search fields

### DIFF
--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-search-configuration.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-search-configuration.xml
@@ -74,7 +74,7 @@
                 <property name="type" value="file"/>
                 <property name="enable" value="${exo.unified-search.connector.file.enable:true}"/>
                 <property name="titleField" value="title"/>
-                <property name="searchFields" value="name,title,attachment.content"/>
+                <property name="searchFields" value="name,title,attachment.content,dc:title,dc:creator,dc:subject,dc:description,dc:publisher,dc:contributor,dc:resourceType,dc:format,dc:identifier,dc:source,dc:language,dc:relation,dc:coverage,dc:rights"/>
             </properties-param>
         </init-params>
     </component>


### PR DESCRIPTION
This PR adds the dublin core metadata in search fields when searching for files (except dc:date since it is mapped as a date).