### PR TITLE
ECMS-7708 : store comments with user session instead of system session

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/comments/impl/CommentsServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/comments/impl/CommentsServiceImpl.java
@@ -85,11 +85,8 @@ public class CommentsServiceImpl implements CommentsService {
       listenerService = WCMCoreUtils.getService(ListenerService.class);
     }
     Session session = node.getSession();
-    ManageableRepository  repository = (ManageableRepository)session.getRepository();
-    //TODO check if really need delegate to system session
-    Session systemSession = repository.getSystemSession(session.getWorkspace().getName()) ;
     try {
-      Node document = (Node)systemSession.getItem(node.getPath()) ;
+      Node document = (Node)session.getItem(node.getPath());
       if(!document.isNodeType(COMMENTABLE)) {
         if(document.canAddMixin(COMMENTABLE)) document.addMixin(COMMENTABLE) ;
         else throw new Exception("This node does not support comments.") ;
@@ -145,7 +142,7 @@ public class CommentsServiceImpl implements CommentsService {
         newComment.setProperty(COMMENTOR_SITE,site) ;
       }
       document.save();
-      systemSession.save();
+      session.save();
       if (listenerService!=null) {
         try {
           if (activityService.isAcceptedNode(document) 
@@ -164,8 +161,6 @@ public class CommentsServiceImpl implements CommentsService {
       if (LOG.isErrorEnabled()) {
         LOG.error("Unexpected problem happen when try to add comment", e);
       }
-    } finally {
-      systemSession.logout();
     }
 
   }

--- a/core/services/src/test/java/org/exoplatform/services/ecm/dms/comment/TestCommentService.java
+++ b/core/services/src/test/java/org/exoplatform/services/ecm/dms/comment/TestCommentService.java
@@ -33,8 +33,6 @@ import org.exoplatform.services.cms.JcrInputProperty;
 import org.exoplatform.services.cms.comments.CommentsService;
 import org.exoplatform.services.cms.i18n.MultiLanguageService;
 import org.exoplatform.services.wcm.BaseWCMTestCase;
-import org.junit.FixMethodOrder;
-import org.junit.runners.MethodSorters;
 
 /**
  * Created by eXo Platform
@@ -77,9 +75,9 @@ public class TestCommentService extends BaseWCMTestCase {
   
   public void setUp() throws Exception {
     super.setUp();
-    commentsService = (CommentsService) container.getComponentInstanceOfType(CommentsService.class);
-    multiLangService = (MultiLanguageService) container.getComponentInstanceOfType(MultiLanguageService.class);
-    applySystemSession();
+    commentsService = container.getComponentInstanceOfType(CommentsService.class);
+    multiLangService = container.getComponentInstanceOfType(MultiLanguageService.class);
+    applyUserSession("john", "gtn", "collaboration");
     initNode();
   }
 
@@ -97,7 +95,7 @@ public class TestCommentService extends BaseWCMTestCase {
       test.addMixin(I18NMixin);
     }
     session.save();
-    commentsService.addComment(test, "root", "root@explatform.com", null, "Hello", multiLangService.getDefault(test));
+    commentsService.addComment(test, "john", "john@explatform.com", null, "Hello", multiLangService.getDefault(test));
     commentsService.addComment(test, "marry", "marry@explatform.com", null, "Thanks", multiLangService.getDefault(test));
     NodeIterator iter = test.getNode(COMMENT).getNodes();
     int i = 0;
@@ -122,12 +120,12 @@ public class TestCommentService extends BaseWCMTestCase {
       test.addMixin(I18NMixin);
     }
     session.save();
-    commentsService.addComment(test, "root", "root@explatform.com", null, "Hello", "jp");
+    commentsService.addComment(test, "john", "john@explatform.com", null, "Hello", "jp");
     NodeIterator iter = test.getNode(COMMENT).getNodes();
     while (iter.hasNext()) {
       Node node = iter.nextNode();
-      assertEquals("root", node.getProperty(COMMENTOR).getString());
-      assertEquals("root@explatform.com", node.getProperty(COMMENTOR_EMAIL).getString());
+      assertEquals("john", node.getProperty(COMMENTOR).getString());
+      assertEquals("john@explatform.com", node.getProperty(COMMENTOR_EMAIL).getString());
       assertEquals("Hello", node.getProperty(COMMENTOR_MESSAGES).getString());
     }
   }
@@ -141,10 +139,6 @@ public class TestCommentService extends BaseWCMTestCase {
    */
   public void testAddComment3() throws Exception{
     Node test = session.getRootNode().getNode("test");
-    if(test.canAddMixin(I18NMixin)){
-      test.addMixin(I18NMixin);
-    }
-    session.save();
     commentsService.addComment(test, null, "null@explatform.com", null, "Hello", multiLangService.getDefault(test));
     commentsService.addComment(test, null, "abc@explatform.com", null, "Hello", multiLangService.getDefault(test));
     List<Node> listCommentNode = commentsService.getComments(test, multiLangService.getDefault(test));
@@ -165,10 +159,7 @@ public class TestCommentService extends BaseWCMTestCase {
    */
   public void testUpdateComment() throws Exception{
     Node test = session.getRootNode().getNode("test");
-    if(test.canAddMixin(I18NMixin)){
-      test.addMixin(I18NMixin);
-    }
-    commentsService.addComment(test, "root", "root@explatform.com", null, "Hello", multiLangService.getDefault(test));
+    commentsService.addComment(test, "john", "john@explatform.com", null, "Hello", multiLangService.getDefault(test));
     List<Node> nodes = commentsService.getComments(test, multiLangService.getDefault(test));
     commentsService.updateComment(nodes.get(0), "Ciao");
     nodes = commentsService.getComments(test, multiLangService.getDefault(test));
@@ -184,13 +175,14 @@ public class TestCommentService extends BaseWCMTestCase {
    */
   public void testDeleteComment() throws Exception{
     Node test = session.getRootNode().getNode("test");
-    commentsService.addComment(test, "root", "root@explatform.com", null, "Hello", multiLangService.getDefault(test));
+    commentsService.addComment(test, "john", "john@explatform.com", null, "Hello", multiLangService.getDefault(test));
     List<Node> nodes = commentsService.getComments(test, multiLangService.getDefault(test));
     assertEquals(1, nodes.size());
     commentsService.deleteComment(nodes.get(0));
     nodes = commentsService.getComments(test, multiLangService.getDefault(test));
     assertEquals(0, nodes.size());
   }
+
   /**
    * Test Method: getComments()
    * Input: Test node doesn't have languages node, so adding comment nodes will be set default
@@ -200,11 +192,7 @@ public class TestCommentService extends BaseWCMTestCase {
    */
   public void testGetComments1() throws Exception{
     Node test = session.getRootNode().getNode("test");
-    if(test.canAddMixin(I18NMixin)){
-      test.addMixin(I18NMixin);
-    }
-    session.save();
-    commentsService.addComment(test, "root", "root@explatform.com", null, "Hello", multiLangService.getDefault(test));
+    commentsService.addComment(test, "john", "john@explatform.com", null, "Hello", multiLangService.getDefault(test));
     commentsService.addComment(test, "marry", "marry@explatform.com", null, "Thanks", multiLangService.getDefault(test));
     List<Node> listCommentNode = commentsService.getComments(test, multiLangService.getDefault(test));
     Collections.sort(listCommentNode, new NameComparator());
@@ -223,12 +211,8 @@ public class TestCommentService extends BaseWCMTestCase {
    */
   public void testGetComments2() throws Exception{
     Node test = session.getRootNode().getNode("test");
-    if(test.canAddMixin(I18NMixin)){
-      test.addMixin(I18NMixin);
-    }
-    session.save();
     multiLangService.addLanguage(test, createMapInput(), "jp", false);
-    commentsService.addComment(test, "root", "root@explatform.com", null, "Hello", "jp");
+    commentsService.addComment(test, "john", "john@explatform.com", null, "Hello", "jp");
     commentsService.addComment(test, "marry", "marry@explatform.com", null, "Thanks", "jp");
 
     List<Node> listCommentNode = commentsService.getComments(test, "jp");
@@ -298,8 +282,8 @@ public class TestCommentService extends BaseWCMTestCase {
   private void check(int i, Node node) throws Exception{
     switch (i) {
     case 0:
-      assertEquals("root", node.getProperty(COMMENTOR).getString());
-      assertEquals("root@explatform.com", node.getProperty(COMMENTOR_EMAIL).getString());
+      assertEquals("john", node.getProperty(COMMENTOR).getString());
+      assertEquals("john@explatform.com", node.getProperty(COMMENTOR_EMAIL).getString());
       assertEquals("Hello", node.getProperty(COMMENTOR_MESSAGES).getString());
       break;
     case 1:


### PR DESCRIPTION
The issue comes from 2 things:
* A given user does not have deletion permissions on his Personal drive, whereas he has deletion permissions on Personal default folders (Documents, Pictures, Music, ...)
* a comment is created with a system session (not an user session), so the owner is "_system"

So when a comment is created on a document inside one of the default folders, the user inherits the permissions from it and therefore has the right to delete a comment (even he is not the owner of the comment node). But when the document is created at the root of the drive, the permissions are inherited from the drive, so the user does not have deletion permissions on this node, and since he is not the owner of the comment (since it has been created with a system session), he cannot delete the comment. We do not have this issue on files themselves since the user is the owner of the files nodes, so he can do anything with them.

This PR uses the user session instead of the system session to create the comments. It allows the user who created the comment to have full permissions on the comment and therefore to delete it.