### PR TITLE
ECMS-7724 : change the IsNotIgnoreVersionNodeFilter filter to only exclude child nodes of configured node types

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/filter/IsNotIgnoreVersionNodeFilter.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/filter/IsNotIgnoreVersionNodeFilter.java
@@ -35,10 +35,12 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Created by The eXo Platform SAS
- * Author : Ha Quang Tan
- *          tanhq@exoplatform.com
- * Mar 6, 2012
+ * This filter excludes all the child nodes of the nodes having a node type defined in "wcm.nodetypes.ignoreversion".
+ * The node types defined in this property must be separated by comas.
+ * The default value is "exo:webContent".
+ * The goal is to not manage versions in child nodes of a complex type. For example a exo:webContent node has some
+ * child nodes which compose the content (html, css, js, images, ...). The versions must be managed at the webContent
+ * level, not on each of these child nodes.
  */
 public class IsNotIgnoreVersionNodeFilter implements UIExtensionFilter {
 
@@ -77,11 +79,6 @@ public class IsNotIgnoreVersionNodeFilter implements UIExtensionFilter {
    Node parentNode = currentNode;
 
    do {
-     for(NodeType nodetype : ignoredNodetypes) {
-       if (parentNode.isNodeType(nodetype.getName())) {
-         return false;
-       }
-     }
      try {
        parentNode = parentNode.getParent();
      } catch(AccessDeniedException ex) {
@@ -90,6 +87,11 @@ public class IsNotIgnoreVersionNodeFilter implements UIExtensionFilter {
      } catch(Exception ex) {
        LOG.error("Error while getting parent of node " + parentNode.getPath(), ex);
        return false;
+     }
+     for(NodeType nodetype : ignoredNodetypes) {
+       if (parentNode.isNodeType(nodetype.getName())) {
+         return false;
+       }
      }
    } while (!((NodeImpl) parentNode).isRoot());
 

--- a/core/webui-explorer/src/test/java/org/exoplatform/ecm/webui/component/explorer/control/filter/IsNotIgnoreVersionNodeFilterTest.java
+++ b/core/webui-explorer/src/test/java/org/exoplatform/ecm/webui/component/explorer/control/filter/IsNotIgnoreVersionNodeFilterTest.java
@@ -59,7 +59,7 @@ public class IsNotIgnoreVersionNodeFilterTest extends BaseECMSTestCase {
     assertTrue(accept);
   }
 
-  public void testShouldReturnFalseWhenNoParamAndNodeWebContent() throws Exception {
+  public void testShouldReturnTrueWhenNoParamAndNodeWebContent() throws Exception {
     // Given
     System.clearProperty(IsNotIgnoreVersionNodeFilter.NODETYPES_IGNOREVERSION_PARAM);
 
@@ -77,7 +77,7 @@ public class IsNotIgnoreVersionNodeFilterTest extends BaseECMSTestCase {
     boolean accept = filter.accept(context);
 
     // Then
-    assertFalse(accept);
+    assertTrue(accept);
   }
 
   public void testShouldReturnFalseWhenNodeChildOfWebContent() throws Exception {


### PR DESCRIPTION
This bug is a regression of https://jira.exoplatform.org/browse/ECMS-7693. The filter must only exclude the child nodes of the node with the configured node types (in "wcm.nodetypes.ignoreversion"), whereas it excludes also the node. This PR allows to not exclude the main node anymore.
It has been tested successfully for the current issue and also for https://jira.exoplatform.org/browse/ECMS-7693.