### PR TITLE
ECMS-7738 : remove DocumentConnector component from confgiration since the class has been deleted

### DIFF
--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-connector-configuration.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-connector-configuration.xml
@@ -29,9 +29,6 @@
     <type>org.exoplatform.wcm.connector.collaboration.CommentConnector</type>
   </component>
   <component>
-    <type>org.exoplatform.wcm.connector.documents.DocumentConnector</type>
-  </component>
-  <component>
     <type>org.exoplatform.wcm.connector.collaboration.RssConnector</type>
   </component>
   <component>


### PR DESCRIPTION
The class org.exoplatform.wcm.connector.documents.DocumentConnector has been removed in https://jira.exoplatform.org/browse/ECMS-7719 but not the component declaration.