### PR TITLE
ECMS-7744 : add the option isWebContent to true when the previewed document in the versions screen is a web content to display it correctly

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/versions/UIVersionInfo.gtmpl
+++ b/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/versions/UIVersionInfo.gtmpl
@@ -147,7 +147,8 @@ import java.util.Locale;
                     }
                     def docDownloadUrl = org.exoplatform.wcm.webui.Utils.getDownloadLink(currentVersionNode);
                     def docOpenUri = uicomponent.getLinkInDocumentsApp(currentNode.getPath());
-                    def docPreviewUri = "javascript:require(['SHARED/documentPreview'], function(documentPreview) {documentPreview.init({doc: {id:'" + currentVersionNode.getUUID() + "', fileType: '" + fileType +"', repository:'" + repository + "', workspace:'" + preferenceWS + "', path:'" + currentNode.getPath() + "', title:'" + currentNode.getName() + "', downloadUrl:'" + docDownloadUrl + "', openUrl:'" + docOpenUri + "'}, version: {number:'" + versionNumber + "'}, author: {username:'" + authorUserName + "', fullname:'" + authorFullName + "', avatarUrl:'" + avatarURL + "', profileUrl:'" + profileURL + "'}})})";
+                    def isWebContent = uicomponent.isWebContent();
+                    def docPreviewUri = "javascript:require(['SHARED/documentPreview'], function(documentPreview) {documentPreview.init({doc: {id:'" + currentVersionNode.getUUID() + "', fileType: '" + fileType +"', repository:'" + repository + "', workspace:'" + preferenceWS + "', path:'" + currentNode.getPath() + "', title:'" + currentNode.getName() + "', downloadUrl:'" + docDownloadUrl + "', openUrl:'" + docOpenUri + "', isWebContent: " + isWebContent + "}, version: {number:'" + versionNumber + "'}, author: {username:'" + authorUserName + "', fullname:'" + authorFullName + "', avatarUrl:'" + avatarURL + "', profileUrl:'" + profileURL + "'}})})";
                 %>
                 <a class="btn" onclick="<%=docPreviewUri %>" rel="tooltip" data-placement="bottom" title="<%= _ctx.appRes('UIVersionInfo.tooltip.viewVersion'); %>"><i class="uiIconWatch uiIconLightGray"></i></a>
                 <%

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/versions/UIVersionInfo.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/versions/UIVersionInfo.java
@@ -273,6 +273,14 @@ public class UIVersionInfo extends UIContainer  {
     return rootVersionNum_;
   }
 
+  private boolean isWebContent() throws Exception {
+    Node currentNode = getCurrentNode();
+    if (currentNode != null) {
+      return currentNode.isNodeType(Utils.EXO_WEBCONTENT);
+    }
+    return false;
+  }
+
   static  public class RestoreVersionActionListener extends EventListener<UIVersionInfo> {
     public void execute(Event<UIVersionInfo> event) throws Exception {
       UIVersionInfo uiVersionInfo = event.getSource();


### PR DESCRIPTION
The call to documentPreview js component from the Versions screen does not include the isWebContent option. It is required to display web contents correctly.