### PR TITLE
PLF-7808 : rename some javascript modules to not have 3-letters at the end, since lang on 3 letters are now allowed

### DIFF
--- a/apps/portlet-seo/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/apps/portlet-seo/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -19,13 +19,13 @@
     <name>SEOToolbarPortlet</name>
     <module>
       <depends>
-        <module>ecm-seo</module>
+        <module>ecm-seo-popup</module>
       </depends>
     </module>
   </portlet>
 
   <module>
-    <name>ecm-seo</name>
+    <name>ecm-seo-popup</name>
     <as>ecmSeo</as>
     <script>
       <path>/javascript/eXo/webui/WCMUIPopupWindow.js</path>

--- a/apps/resources-wcm/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/apps/resources-wcm/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -106,7 +106,7 @@
   </module>
   
   <module>
-    <name>wcm-webui-ext</name>
+    <name>wcm-webui-extension</name>
     <as>wcm_webui_ext</as>
     <script>
       <path>/javascript/eXo/wcm/backoffice/private/CloseEvents.js</path>
@@ -144,8 +144,8 @@
   </module>
   
   <module>
-    <name>ui-vertical-slide-tab</name>
-    <as>ui_vertical_slide_tab</as>
+    <name>ui-vertical-slide-tabs</name>
+    <as>ui_vertical_slide_tabs</as>
     <script>
       <path>/javascript/eXo/wcm/backoffice/private/UIVerticalSlideTabs.js</path>
     </script>

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/actions/UICommentForm.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/actions/UICommentForm.java
@@ -145,11 +145,11 @@ public class UICommentForm extends UIForm implements UIPopupComponent {
 
   /**
    * Overrides method processRender of UIForm, loads javascript module
-   * wcm-webui-ext
+   * wcm-webui-extension
    */
   @Override
   public void processRender(WebuiRequestContext context) throws Exception {
-    context.getJavascriptManager().loadScriptResource("wcm-webui-ext");
+    context.getJavascriptManager().loadScriptResource("wcm-webui-extension");
     super.processRender(context);
   }
 

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/actions/UIDocumentForm.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/actions/UIDocumentForm.java
@@ -248,7 +248,7 @@ public class UIDocumentForm extends UIDialogForm implements UIPopupComponent, UI
     addScripts("uiDocumentForm.UIDocForm.UpdateGUI();").
     addScripts("uiDocumentForm.UIDocForm.AutoFocus();");
 
-    context.getJavascriptManager().loadScriptResource("wcm-webui-ext");
+    context.getJavascriptManager().loadScriptResource("wcm-webui-extension");
     context.getJavascriptManager().addCustomizedOnLoadScript("changeWarning();");
     super.processRender(context);
   }

--- a/core/webui-fcc/src/main/java/org/exoplatform/wcm/webui/fastcontentcreator/UIFCCForm.java
+++ b/core/webui-fcc/src/main/java/org/exoplatform/wcm/webui/fastcontentcreator/UIFCCForm.java
@@ -279,7 +279,7 @@ public class UIFCCForm extends UIDialogForm implements UISelectable {
 
   @Override
   public void processRender(WebuiRequestContext context) throws Exception {
-    context.getJavascriptManager().loadScriptResource("wcm-webui-ext");
+    context.getJavascriptManager().loadScriptResource("wcm-webui-extension");
     context.getJavascriptManager().addCustomizedOnLoadScript("changeWarning();");
     super.processRender(context);
   }  

--- a/ext/fastcontentcreator/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/ext/fastcontentcreator/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -33,7 +33,7 @@
 	  		<module>ecm-utils</module>
 	  	</depends>
 	  	<depends>
-	  		<module>wcm-webui-ext</module>	  		
+	  		<module>wcm-webui-extension</module>
 	  	</depends>
 	  </module>  
   </portlet>
@@ -45,7 +45,7 @@
 	  		<module>ecm-utils</module>
 	  	</depends>
 	  	<depends>
-	  		<module>wcm-webui-ext</module>	  		
+	  		<module>wcm-webui-extension</module>
 	  	</depends>
 	  </module>  
   </portlet>
@@ -57,7 +57,7 @@
 	  		<module>ecm-utils</module>
 	  	</depends>
 	  	<depends>
-	  		<module>wcm-webui-ext</module>	  		
+	  		<module>wcm-webui-extension</module>
 	  	</depends>
 	  </module>  
   </portlet>


### PR DESCRIPTION
The lang parameter in routes of scripts can now be 2 or 3 letters, so it fails when the scripts ends with a 3-letters part (wcm-webui-ext for example). This PR changes these cases to have more than 3 letters at the end.