### PR TITLE
PLF-7873 : use portal name instead of site name for variable portalName when importing contents

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/wcm/webcontent/InitialWebContentPlugin.java
+++ b/core/services/src/main/java/org/exoplatform/services/wcm/webcontent/InitialWebContentPlugin.java
@@ -192,7 +192,7 @@ public class InitialWebContentPlugin extends CreatePortalPlugin {
       if(!mimeType.startsWith("text") && !mimeType.startsWith("application/x-javascript")) continue;
       String jcrData = ntResource.getProperty("jcr:data").getString();
       
-      jcrData = replace(jcrData, "{portalName}", siteName);
+      jcrData = replace(jcrData, "{portalName}", WCMCoreUtils.getPortalName());
       jcrData = replace(jcrData, "{restContextName}", WCMCoreUtils.getRestContextName());
       jcrData = replace(jcrData, "{repositoryName}", WCMCoreUtils.getRepository().getConfiguration().getName());
       jcrData = replace(jcrData, "{workspaceName}", targetNode.getSession().getWorkspace().getName());


### PR DESCRIPTION
This fix reverts the change made for ECMS-7381 since portalName should refer to the portal name and siteName to the site name.
A fix is done in platform project to fix the problem raised by ECMS-7381.