### PR TITLE
PLF-8324 : use offsets option for index_options of file attachment mapping

### DIFF
--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/FileindexingConnector.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/FileindexingConnector.java
@@ -69,6 +69,7 @@ public class FileindexingConnector extends ElasticIndexingServiceConnector {
             .append("    \"permissions\" : {\"type\" : \"keyword\"},\n")
             .append("    \"createdDate\" : {\"type\" : \"date\", \"format\": \"epoch_millis\"},\n")
             .append("    \"lastUpdatedDate\" : {\"type\" : \"date\", \"format\": \"epoch_millis\"},\n")
+            .append("    \"attachment\" : { \"properties\" : { \"content\" : {\"type\" : \"text\", \"index_options\": \"offsets\", \"fields\" : {\"keyword\" : {\"type\" : \"keyword\", \"ignore_above\" : 256}}}}},\n")
             .append("    \"fileType\" : {\"type\" : \"keyword\"},\n")
             .append("    \"fileSize\" : {\"type\" : \"long\"},\n")
             .append("    \"name\" : {\"type\" : \"text\", \"analyzer\": \"letter_lowercase_asciifolding\"},\n")


### PR DESCRIPTION
No explicit mapping were defined for the file attachment content field. The default mapping does not define any value for index_options so the default value 'positions' was applied. This value does not store the start and end character offsets of the words, which are used to speed up highlighting. As explainded in the Elasticsearch, without these offsets, the highlithing process creates a tiny in-memory index and re-runs the original query criteria through Lucene’s query execution planner to get access to low-level match information on the current document. This leads to bad performances when it involves a lot of documents.

This fix updates the file mapping to use the offsets option for index_options and speed up the highlighting process.