### PR TITLE
PLF-6637 : consider /spaces group when checking permissions in group selector

### DIFF
--- a/core/webui/src/main/java/org/exoplatform/ecm/webui/selector/PermissionsGroupVisibilityPlugin.java
+++ b/core/webui/src/main/java/org/exoplatform/ecm/webui/selector/PermissionsGroupVisibilityPlugin.java
@@ -31,7 +31,9 @@ public class PermissionsGroupVisibilityPlugin extends GroupVisibilityPlugin {
                           .anyMatch(userMembership -> userMembership.getGroup().equals(userACL.getAdminGroups())
                               || ((userMembership.getGroup().equals(group.getId())
                                   || userMembership.getGroup().startsWith(group.getId() + "/"))
-                                  && (group.getId().startsWith("/spaces/") || userMembership.getMembershipType().equals("*")
+                                  && (group.getId().equals("/spaces")
+                                      || group.getId().startsWith("/spaces/")
+                                      || userMembership.getMembershipType().equals("*")
                                       || userMembership.getMembershipType().equals("manager"))));
   }
 }

--- a/core/webui/src/test/java/org/exoplatform/ecm/webui/selector/PermissionsGroupVisibilityPluginTest.java
+++ b/core/webui/src/test/java/org/exoplatform/ecm/webui/selector/PermissionsGroupVisibilityPluginTest.java
@@ -116,4 +116,36 @@ public class PermissionsGroupVisibilityPluginTest {
     assertTrue(hasPermissionOnOrganizationRh);
   }
 
+  @Test
+  public void shouldHasPermissionWhenUserIsOnlyMemberOfSpaces() {
+    // Given
+    UserACL userACL = mock(UserACL.class);
+    when(userACL.getSuperUser()).thenReturn("root");
+    when(userACL.getAdminGroups()).thenReturn("/platform/administrators");
+    GroupVisibilityPlugin plugin = new PermissionsGroupVisibilityPlugin(userACL);
+
+    Identity userIdentity = new Identity("john",
+            Arrays.asList(new MembershipEntry("/spaces/marketing", "member"),
+                    new MembershipEntry("/spaces/sales", "redactor")));
+    Group groupSpaces = new GroupImpl();
+    groupSpaces.setId("/spaces");
+    Group groupSpacesMarketing = new GroupImpl();
+    groupSpacesMarketing.setId("/spaces/marketing");
+    Group groupSpacesSales = new GroupImpl();
+    groupSpacesSales.setId("/spaces/sales");
+    Group groupSpacesEngineering = new GroupImpl();
+    groupSpacesEngineering.setId("/spaces/engineering");
+
+    // When
+    boolean hasPermissionOnSpaces = plugin.hasPermission(userIdentity, groupSpaces);
+    boolean hasPermissionOnSpacesMarketing = plugin.hasPermission(userIdentity, groupSpacesMarketing);
+    boolean hasPermissionOnSpacesSales = plugin.hasPermission(userIdentity, groupSpacesSales);
+    boolean hasPermissionOnSpacesEngineering = plugin.hasPermission(userIdentity, groupSpacesEngineering);
+
+    // Then
+    assertTrue(hasPermissionOnSpaces);
+    assertTrue(hasPermissionOnSpacesMarketing);
+    assertTrue(hasPermissionOnSpacesSales);
+    assertFalse(hasPermissionOnSpacesEngineering);
+  }
 }


### PR DESCRIPTION
In order to display sub-groups of /spaces, the group /spaces must also be available for the user when he/she can see a space group. This fix adds a check on this group to return it and allows to see spaces groups.