### PR TITLE
MAINT-27305: Make sure that no error appears when pasting a folder.

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/PasteManageComponent.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/PasteManageComponent.java
@@ -573,7 +573,7 @@ public class PasteManageComponent extends UIAbstractManagerComponent {
         destNode = (Node) destSession.getItem(destPath);
       }
 
-      if (!srcWorkspace.equals(destWorkspace) || !srcPath.equals(destPath)) {
+      if (!srcWorkspace.equals(destWorkspace) || !srcPath.equals(destPath) && srcThumbnailNode != null) {
         // Remove thumbnail from source folder after moving it
 
         thumbnailService.processRemoveThumbnail(srcThumbnailNode);


### PR DESCRIPTION
The issue is that when pasting a folder an error pop up shows up, but the folder is correctly pasted.
After digging in this issue i found out that in the process of pasting the folder there is an action of deleting a thumbnail node which is null so i added a check to avoid this error.